### PR TITLE
subtract 1 from address when not top of frame

### DIFF
--- a/src/CallpathRuntime.C
+++ b/src/CallpathRuntime.C
@@ -1,29 +1,34 @@
-//////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2010-2014, Lawrence Livermore National Security, LLC.
-// Produced at the Lawrence Livermore National Laboratory.
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2010, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory
+// Written by Todd Gamblin, tgamblin@llnl.gov.
+// LLNL-CODE-417602
+// All rights reserved.
 //
-// This file is part of the Callpath library.
-// Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
-// LLNL-CODE-647183
+// This file is part of Libra. For details, see http://github.com/tgamblin/libra.
+// Please also read the LICENSE file for further information.
 //
-// For details, see https://github.com/scalability-llnl/callpath
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
 //
-// For details, see https://scalability-llnl.github.io/spack
-// Please also see the LICENSE file for our notice and the LGPL.
+//  * Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the disclaimer below.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//    conditions and the disclaimer (as noted below) in the documentation and/or other materials
+//    provided with the distribution.
+//  * Neither the name of the LLNS/LLNL nor the names of its contributors may be used to endorse
+//    or promote products derived from this software without specific prior written permission.
 //
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License (as published by
-// the Free Software Foundation) version 2.1 dated February 1999.
-//
-// This program is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
-// conditions of the GNU General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-//////////////////////////////////////////////////////////////////////////////
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// LAWRENCE LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/////////////////////////////////////////////////////////////////////////////////////////////////
 #include "CallpathRuntime.h"
 
 #include "unistd.h"
@@ -143,16 +148,24 @@ Callpath CallpathRuntime::doStackwalk(size_t wrap_level) {
   // build up a temporary callpath
   vector<FrameId> temp;
   for (size_t i=start;
-       i < swalk.size() && libc_start_main_addr != swalk[i].getRA();
+       i < swalk.size() && swalk[i] != swalk[i].getRA();
        i++) {
     Dyninst::Offset offset;
     string modname;
     void *symtab;
 
     if (!swalk[i].getLibOffset(modname, offset, symtab)) {
-      temp.push_back(FrameId(ModuleId(), swalk[i].getRA()));
+      if (swalk[i].isTopFrame()) {
+        temp.push_back(FrameId(ModuleId(), swalk[i].getRA()));
+      } else {
+        temp.push_back(FrameId(ModuleId(), swalk[i].getRA() - 1));
+      }
     } else {
-      temp.push_back(FrameId(modname, offset));
+      if (!swalk[i].isTopFrame()) {
+        offset -= 1;
+      }
+      temp.push_back(FrameId(modname, offset)
+      );
     }
   }
 


### PR DESCRIPTION
I do this in STAT already. If you previously ran addr2line on the addresses returned from tests/runtime-test, you will notice that the line numbers are slightly off. This PR fixes that.