### PR TITLE
subtract 1 from address when not top of frame

### DIFF
--- a/src/CallpathRuntime.C
+++ b/src/CallpathRuntime.C
@@ -150,9 +150,17 @@ Callpath CallpathRuntime::doStackwalk(size_t wrap_level) {
     void *symtab;
 
     if (!swalk[i].getLibOffset(modname, offset, symtab)) {
-      temp.push_back(FrameId(ModuleId(), swalk[i].getRA()));
+      if (swalk[i].isTopFrame()) {
+        temp.push_back(FrameId(ModuleId(), swalk[i].getRA()));
+      } else {
+        temp.push_back(FrameId(ModuleId(), swalk[i].getRA() - 1));
+      }
     } else {
-      temp.push_back(FrameId(modname, offset));
+      if (!swalk[i].isTopFrame()) {
+        offset -= 1;
+      }
+      temp.push_back(FrameId(modname, offset)
+      );
     }
   }
 


### PR DESCRIPTION
Fix for #7... I do this in STAT already. If you previously ran addr2line on the addresses returned from tests/runtime-test, you will notice that the line numbers are slightly off. This PR fixes that.